### PR TITLE
Created Separate Class Library for Backend Classes

### DIFF
--- a/BRIM.csproj
+++ b/BRIM.csproj
@@ -24,6 +24,10 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="BackendClassLibrary\BackendClassLibrary.csproj" />
+  </ItemGroup>
+
   <Target Name="ReactBuild" AfterTargets="Build">
     <Exec Command="npm i &amp;&amp; npm run build" />
   </Target>

--- a/BRIM.sln
+++ b/BRIM.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30804.86
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BRIM", "BRIM.csproj", "{7B5E82B8-388E-4371-8442-36F61C085767}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackendClassLibrary", "BackendClassLibrary\BackendClassLibrary.csproj", "{4663DF12-FDB1-44D1-BDD2-271F4154F596}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{7B5E82B8-388E-4371-8442-36F61C085767}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7B5E82B8-388E-4371-8442-36F61C085767}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7B5E82B8-388E-4371-8442-36F61C085767}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4663DF12-FDB1-44D1-BDD2-271F4154F596}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4663DF12-FDB1-44D1-BDD2-271F4154F596}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4663DF12-FDB1-44D1-BDD2-271F4154F596}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4663DF12-FDB1-44D1-BDD2-271F4154F596}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BackendClassLibrary/BackendClassLibrary.csproj
+++ b/BackendClassLibrary/BackendClassLibrary.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute> 
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MySql.Data" Version="8.0.22" />
+    <PackageReference Include="Newtonsoft.json" Version="12.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/BackendClassLibrary/DatabaseManager.cs
+++ b/BackendClassLibrary/DatabaseManager.cs
@@ -6,7 +6,7 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace BRIM
+namespace BackendClassLibrary
 {
     public class DatabaseManager
     {

--- a/BackendClassLibrary/Drink.cs
+++ b/BackendClassLibrary/Drink.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Data;
 
-namespace BRIM
+namespace BackendClassLibrary
 {
     public class Drink : Item
     {

--- a/BackendClassLibrary/Inventory.cs
+++ b/BackendClassLibrary/Inventory.cs
@@ -7,7 +7,7 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace BRIM
+namespace BackendClassLibrary
 {
     //The main class of the program. 
     public class Inventory

--- a/BackendClassLibrary/Item.cs
+++ b/BackendClassLibrary/Item.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace BRIM
+namespace BackendClassLibrary
 {
     public enum unit { milliliters, ounces } //standard measurement units
     public enum status { empty, belowPar, belowIdeal, aboveIdeal } //the status of an inventory item

--- a/BackendClassLibrary/Recipe.cs
+++ b/BackendClassLibrary/Recipe.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace BRIM
+namespace BackendClassLibrary
 {
     public class Recipe
     {

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,9 @@
 using System;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using BackendClassLibrary;	
+//why is This Using Directive unneccesary? Is it because it's not in a 
+//separate Project, but rather a free-floating file in the project that contain the Class Library? 
 
 //namespace React.Sample.Webpack.CoreMvc
 namespace BRIM


### PR DESCRIPTION
and moved Item, Drink, Recipe, Inventory, and
DatabaseManager into said Class Library, and added references to it in
the main BRIM project.
NOTE: code compiles and works fine (at least the back end part does when
I tested it running Program.Main") but classes in BackendClassLibrary
will still throw errors about conflicting with themselves.
When I looked online, the answers where either that it was something to
ignore, or possibly the result of circular references within one of the
projects. Either way, It's not something I can solve, as inuitive
C# project management is not one of VScode's strengths