### PR TITLE
Aab385 recipe backend unit tests

### DIFF
--- a/BackendClassLibrary/DatabaseManager.cs
+++ b/BackendClassLibrary/DatabaseManager.cs
@@ -99,22 +99,22 @@ namespace BRIM.BackendClassLibrary
         public bool deleteDrink(Drink drink)
         {
             int drinkID = drink.ID;
-            string query = @"delete from brim.drinks where drinkID = '" + drink.ID + "'";
+            string query = @"delete from brim.drinktags where drinkID = '" + drinkID + "'";
             bool result = this.runSqlInsertUpdateOrDeleteCommand(query);
 
             if (!result)
             {
-                Console.WriteLine("Error: Drink could not be deleted");
+                Console.WriteLine("Error: Associated DrinkTags for removed drink could not be deleted");
 
                 return false;
             }
 
-            query = @"delete from brim.drinktags where drinkID = '" + drinkID + "'";
+            query = @"delete from brim.drinks where drinkID = '" + drink.ID + "'";
             result = this.runSqlInsertUpdateOrDeleteCommand(query);
 
             if (!result)
             {
-                Console.WriteLine("Error: Associated tags for removed drink could not be deleted");
+                Console.WriteLine("Error: Drink could not be deleted");
 
                 return false;
             }
@@ -322,8 +322,18 @@ namespace BRIM.BackendClassLibrary
         //Deletes a tag from the tags table by ID
         public bool deleteTag(int ID)
         {
-            string query = @"delete from brim.tags where ID = '" + ID + "';";
+            string query = @"delete from brim.drinktags where tagID = '" + ID + "'";
             bool result = this.runSqlInsertUpdateOrDeleteCommand(query);
+
+            if (!result)
+            {
+                Console.WriteLine("Error: Associated DrinkTags for removed Tag could not be deleted");
+
+                return false;
+            }
+
+            query = @"delete from brim.tags where ID = '" + ID + "';";
+            result = this.runSqlInsertUpdateOrDeleteCommand(query);
 
             if (!result)
             {

--- a/BackendClassLibrary/Drink.cs
+++ b/BackendClassLibrary/Drink.cs
@@ -17,15 +17,18 @@ namespace BRIM.BackendClassLibrary
         public double IdealLevel { get; set; }
         public unit Measurement { get; set; }
         public status Status { get; set; }
+        public List<Tag> Tags { get; set; } 
 
         //drink properties
         public int BottleSize {get; set ;}
         public string Brand {get; set;}
         public int UnitsPerCase {get; set;}
         public int? Vintage{get;set;}
-        public List<Tag> Tags { get; set; }
+       
 
-        public Drink() { }
+        public Drink() { 
+            Tags = new List<Tag>();
+        }
 
         //Data Conversion Constructor
         //takes a DataRow object(assumed for a drink) and uses the data to create a Drink Object

--- a/BackendClassLibrary/Inventory.cs
+++ b/BackendClassLibrary/Inventory.cs
@@ -406,6 +406,17 @@ namespace BRIM.BackendClassLibrary
         public int AddRecipe(Recipe newRecipe)
         {
             int recipeID, itemListResult;
+            //Validate Recipe ItemList
+            if (!validateDrinkRecipeList(newRecipe.ItemList)) {
+                Console.WriteLine("Error: Recipe Item List Invalid. Not Entering Data Into Table");
+                string mes = newRecipe.Name + " could not be added." + 
+                "\n Error: New Recipe Item List has one or more Invalid Entries. "+
+                "Not Adding New Recipe Name, Base Liquor, Or Ingredients Into Database";
+                NotificationManager.AddNotification(mes);
+
+                return 1;
+            }
+
             //add entry into Recipe Table
             recipeID = this.databaseManager.addRecipe(newRecipe.Name, newRecipe.BaseLiquor);
             if (recipeID == -1)
@@ -429,13 +440,13 @@ namespace BRIM.BackendClassLibrary
                     Console.WriteLine("Error: DrinkRecipe Entry Addition Failed For Entry with '"
                     + itemID + "' ItemID and '" + itemQuantity + "' failed. Stopping here");
 
-                    string mes = component.Item.Name + " could not be added to the recipie";
+                    string mes = component.Item.Name + " could not be added to the recipie." +
+                    "\n Recipe Ingredient Data Entry Stopped There.";
                     NotificationManager.AddNotification(mes);
 
                     return 1;
                 }
             }
-            
             
             // TODO: come up with and implement a better structure for return Codes
             // at the very Least, we should make them an Enum with Proper names for each Code;
@@ -451,6 +462,17 @@ namespace BRIM.BackendClassLibrary
         public int UpdateRecipe(Recipe updatedRecipe)
         {
             int recipeID, itemListResult;
+            //Validate Recipe ItemList
+            if (!validateDrinkRecipeList(updatedRecipe.ItemList)) {
+                Console.WriteLine("Error: Recipe Item List Invalid. Not Entering Data Into Table");
+                string mes = updatedRecipe.Name + " could not be added." + 
+                "\n Error: Updated Recipe Item List has one or more Invalid Entries. " +
+                "Not Updating Recipe Name, Base Liqour, or Ingredients In Database.";
+                NotificationManager.AddNotification(mes);
+
+                return 1;
+            }
+
             //add entry into Recipe Table
             recipeID = updatedRecipe.ID;
             string updatedName = updatedRecipe.Name;
@@ -496,6 +518,22 @@ namespace BRIM.BackendClassLibrary
             
             return 0;
         }
+
+        //Check to make Sure An Added or Updated Recipe's DrinkRecipe is valid before adding it in 
+        private bool validateDrinkRecipeList(List<RecipeItem> itemList) {
+            this.GetItemList();    //ItemList must be populated and uptoDate First                    
+            foreach(RecipeItem component in itemList) {
+                int itemID = component.Item.ID;
+                double itemQuantity = component.Quantity;
+                int drinkFound = this.ItemList.FindIndex(x => x.ID == itemID);
+
+                if (drinkFound == -1 || itemQuantity < 0) {
+                    return false;
+                }
+            }  
+            
+            return true;
+        } 
 
         
         /// <summary>

--- a/BackendClassLibrary/Item.cs
+++ b/BackendClassLibrary/Item.cs
@@ -18,6 +18,7 @@ namespace BRIM.BackendClassLibrary
         double IdealLevel { get; set; }
         unit Measurement { get; set; }
         status Status { get; set; }
+        List<Tag> Tags { get; set; }
 
         Boolean CalculateStatus();
     }

--- a/BackendClassLibrary/Recipe.cs
+++ b/BackendClassLibrary/Recipe.cs
@@ -18,6 +18,16 @@ namespace BRIM.BackendClassLibrary
         //had to explicitly make a default constructor to make a test recipe to mess with the Add and Updates
         public Recipe() {}
 
+        //make a clone of the Current Recipe Obeject
+        public Recipe Clone() {
+            Recipe other = (Recipe) this.MemberwiseClone();
+            other.ItemList = new List<RecipeItem>();
+            foreach(RecipeItem component in ItemList) {
+                other.ItemList.Add(component);
+            }
+            return other;
+        }
+
         //Data Conversion Constructor
         //takes an IEnumerable of DataRow objects(All assumed to be in the form of results from the query
         //in the getRecipes function in DatabaseManager and uses the data to create a recipe Object and 

--- a/BackendClassUnitTests/InventoryTests.cs
+++ b/BackendClassUnitTests/InventoryTests.cs
@@ -13,15 +13,32 @@ namespace BackendClassUnitTests
     {
         private List<Item> fakeDBItems;
         private List<Recipe> fakeDBRecipes;
+        private List<Tag> fakeDBTags;
         private int latestItemID;
         private int latestRecipeID;
+        private int latestTagID;
         //create Mock of Database manager
         private Mock<IDatabaseManager> mockDBManager = new Mock<IDatabaseManager>();
         private Inventory inventory;
 
         public InventoryTests()
         {
-            //set up Fake Database Data
+            //set up Mock Database Data
+            fakeDBTags = new List<Tag> {
+                new Tag {
+                    ID = 1,
+                    Name = "Fake Tag 1"
+                },
+                new Tag {
+                    ID = 2,
+                    Name = "Fake Tag 2"
+                },
+                new Tag {
+                    ID = 3,
+                    Name = "Fake Tag 3"
+                }
+            };
+
             fakeDBItems = new List<Item> {
                 new Drink {
                     ID = 1,
@@ -35,8 +52,12 @@ namespace BackendClassUnitTests
                     BottleSize = 200,
                     Brand = "Fake Brand 1",
                     UnitsPerCase = 10,
-                    Vintage = null
+                    Vintage = null,
+                    Tags = new List<Tag> {
+                        fakeDBTags[0]
+                    }
                 },
+                //drink not used in Any Recipes
                 new Drink {
                     ID = 2,
                     Name = "Fake Drink 2",
@@ -49,7 +70,10 @@ namespace BackendClassUnitTests
                     BottleSize = 400,
                     Brand = "Fake Brand 2",
                     UnitsPerCase = 60,
-                    Vintage = null
+                    Vintage = null,
+                    Tags = new List<Tag> {
+                        fakeDBTags[1]
+                    }
                 },
                 new Drink {
                     ID = 3,
@@ -63,7 +87,11 @@ namespace BackendClassUnitTests
                     BottleSize = 200,
                     Brand = "Fake Brand 1",
                     UnitsPerCase = 10,
-                    Vintage = 1998
+                    Vintage = 1998,
+                    Tags = new List<Tag> {
+                        fakeDBTags[0],
+                        fakeDBTags[1]
+                    }
                 },
                 new Drink {
                     ID = 4,
@@ -77,7 +105,10 @@ namespace BackendClassUnitTests
                     BottleSize = 25,
                     Brand = "Fake Brand 3",
                     UnitsPerCase = 14,
-                    Vintage = null
+                    Vintage = null,
+                    Tags = new List<Tag> {
+                        fakeDBTags[2]
+                    }
                 }
             };
 
@@ -132,16 +163,35 @@ namespace BackendClassUnitTests
             //to simulate the autoincrement effect that the Database has for the Ids
             latestItemID = fakeDBItems.Count();
             latestRecipeID = fakeDBRecipes.Count();
+            latestTagID = fakeDBTags.Count();
 
             //Mockup Methods in mockDBManager
             //Mockups for Drink related Methods
             mockDBManager.Setup(x => x.deleteDrink(It.IsAny<Drink>()))
                 .Returns((Drink drink) => {
-                    
+                    bool drinkUnused = true;
+                    //go through all recipe Items and check to see if Drink in used in any of them
+                    //DataBase will (or at least should), prevent deletions of Drinks with connected
+                    //entries in the DrinkRecipes Table
+                    for (int i = 0; i < latestRecipeID; i++) {
+                        for (int j = 0; j < fakeDBRecipes[i].ItemList.Count(); j++) {
+                            if (fakeDBRecipes[i].ItemList[j].Item.ID == drink.ID) {
+                                drinkUnused = false;
+                                break;
+                            }
+                        }
+                        if (!drinkUnused) {
+                            break;
+                        }
+                    }
+
+                    //If a Recipe uses that drink, drink deletion will Fail
+                    if (!drinkUnused) {
+                        return false;
+                    }
+
                     fakeDBItems = fakeDBItems.Where(x => x.ID != drink.ID).ToList();
                     return true;    
-                    //If a delete Drink fails/returns false, it's probably not going to be the 
-                    //Invetory Method's fault
                 });
 
             mockDBManager.Setup(x => x.addDrink(It.IsAny<Drink>()))
@@ -157,7 +207,11 @@ namespace BackendClassUnitTests
                 .Returns((Drink drink) => {
                     int itemToUpdateIndex = fakeDBItems.FindIndex(x => x.ID == drink.ID);
                     if (itemToUpdateIndex != -1) {
+                        //preserve Item's tag's since updateDrink does not change entries within 
+                        //DrinkTags table
+                        List<Tag> tagListHolder = ((Drink) fakeDBItems[itemToUpdateIndex]).Tags;
                         fakeDBItems[itemToUpdateIndex] = drink;
+                        ((Drink) fakeDBItems[itemToUpdateIndex]).Tags = tagListHolder;
                         return true;
                     } else {
                         return false;
@@ -165,6 +219,8 @@ namespace BackendClassUnitTests
                 });
 
             mockDBManager.Setup(x => x.getDrinks()).Returns(fakeDBItems);
+
+            mockDBManager.Setup(x => x.getTags()).Returns(fakeDBTags);
 
             mockDBManager.Setup(x => x.deleteRecipe(It.IsAny<int>()))
                 .Returns((int recipeID) => {
@@ -216,6 +272,55 @@ namespace BackendClassUnitTests
                     }
                 });
 
+            mockDBManager.Setup(x => x.addDrinkTag(It.IsAny<int>(), It.IsAny<int>()))
+                .Returns((int drinkID, int tagID) => {
+                    Item drink = fakeDBItems.FirstOrDefault(x => x.ID == drinkID);
+                    Tag tag = fakeDBTags.FirstOrDefault(x => x.ID == tagID);
+
+                    if (drink == null || tag == null) {
+                        return false;
+                    } else {
+                        drink.Tags.Add(tag);
+                        return true;
+                    }
+                });
+            
+            mockDBManager.Setup(x => x.addTag(It.IsAny<string>()))
+                .Returns((string newTagName) => {
+                    latestTagID += 1;
+                    Tag tagToAdd = new Tag {
+                        ID = latestTagID,
+                        Name = newTagName
+                    };
+
+                    fakeDBTags.Add(tagToAdd);
+                    return latestTagID;
+                });
+
+            mockDBManager.Setup(x => x.deleteTag(It.IsAny<int>()))
+                .Returns((int tagID) => {
+                    //DataBase Manager Should Automatically delete DrinkTags for Deleted Tags
+                    for (int i = 0; i < latestItemID; i++) {
+                        for (int j = 0; j < ((Drink) fakeDBItems[i]).Tags.Count(); j++) {
+                            if (fakeDBItems[i].Tags[j].ID == tagID) {
+                                fakeDBItems[i].Tags.RemoveAt(j);
+                            }
+                        }
+                    }
+
+                    fakeDBTags = fakeDBTags.Where(x => x.ID != tagID).ToList();
+                    return true;   
+                });
+
+            mockDBManager.Setup(x => x.deleteDrinkTagsByDrinkID(It.IsAny<int>()))
+                .Returns((int drinkID) => {
+                    Item drink = fakeDBItems.FirstOrDefault(x => x.ID == drinkID);
+                    if (drink != null) {
+                       drink.Tags = new List<Tag>();
+                    }
+                    return true; 
+                });
+
             mockDBManager.Setup(x => x.updateRecipe(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
                 .Returns((int recipeID, string name, string baseLiquor) => {
                     Recipe recipe = fakeDBRecipes.FirstOrDefault(x => x.ID == recipeID);
@@ -229,6 +334,7 @@ namespace BackendClassUnitTests
                 });
 
             mockDBManager.Setup(x => x.getRecipes()).Returns(fakeDBRecipes);
+
             inventory = new Inventory(mockDBManager.Object);
         }
 
@@ -317,7 +423,8 @@ namespace BackendClassUnitTests
                 BottleSize = 450,
                 Brand = "Fake Brand 4",
                 UnitsPerCase = 7,
-                Vintage = null
+                Vintage = null,
+                Tags = new List<Tag> {}
             };
             int oldDBItemCount = fakeDBItems.Count();
             int expectedReturnCode = 0;
@@ -347,6 +454,21 @@ namespace BackendClassUnitTests
             //Assert
             Assert.Equal(fakeDBItems.Count(), oldDBItemCount - 1);
             Assert.Null(fakeDBItems.FirstOrDefault(x => x.ID == itemToRemove.ID));
+            Assert.Equal(expectedReturnCode, returnCode);
+        }
+
+        [Fact]
+        public void removeItemTestFailure_ItemUsedInRecipe() {
+            //Arrange
+            var itemToRemove = fakeDBItems[2];
+            int oldDBItemCount = fakeDBItems.Count();
+            int expectedReturnCode = 1;
+
+            //Act
+            int returnCode = inventory.RemoveItem(itemToRemove);
+            //Assert
+            Assert.Equal(fakeDBItems.Count(), oldDBItemCount);
+            Assert.NotNull(fakeDBItems.FirstOrDefault(x => x.ID == itemToRemove.ID));
             Assert.Equal(expectedReturnCode, returnCode);
         }
     }


### PR DESCRIPTION
Updtated InventoryTests and Added Unit Tests for Recipe Backend, Updated AddRecipe and UpdateRecipe Behavior to perform Validation checking of new/updated Recipe Object before writing to database, make Minor Adjustment to DeleteDrink and DeleteTag, so that both methods first clear any connected entries in the DrinkTags Table before attempting to delete the Drink and/or Tag (as not doing it this way would cause Errors).